### PR TITLE
fix: set target option in mount options to be optional

### DIFF
--- a/types/pure.d.ts
+++ b/types/pure.d.ts
@@ -57,9 +57,12 @@ export type Exports<C> = C extends LegacyComponent
  *
  * In Svelte 4, these are the options passed to the component constructor.
  */
-export type MountOptions<C extends Component> = C extends LegacyComponent
-  ? LegacyConstructorOptions<Props<C>>
-  : Parameters<typeof mount<Props<C>, Exports<C>>>[1];
+export type MountOptions<C extends Component> = Omit<
+    C extends LegacyComponent
+        ? LegacyConstructorOptions<Props<C>>
+        : Parameters<typeof mount<Props<C>, Exports<C>>>[1],
+    'target'
+> & { target?: Element | Document | ShadowRoot };
 
 /**
  * Customize how Svelte renders the component.


### PR DESCRIPTION
When trying to render a legacy component and using the `props` object the `target` option is required by TypeScript, when it's not actually required. This changes that by explicitly marking `target` as optional, which fortunately shares the same signature in both Svelte 3/4 and 5, so doesn't seem to require any major change to the types.