### PR TITLE
fix: move `@playwright/test` out of dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,11 +51,11 @@
     "vitest": "^4.0.0"
   },
   "dependencies": {
-    "@playwright/test": "^1.58.2",
     "@testing-library/svelte-core": "^1.0.0"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^2.24.1",
+    "@playwright/test": "^1.58.2",
     "@sveltejs/vite-plugin-svelte": "^6.2.1",
     "@types/node": "^24.10.1",
     "@vitest/browser-playwright": "4.1.0-beta.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@playwright/test':
-        specifier: ^1.58.2
-        version: 1.58.2
       '@testing-library/svelte-core':
         specifier: ^1.0.0
         version: 1.0.0(svelte@5.34.2)
@@ -18,6 +15,9 @@ importers:
       '@antfu/eslint-config':
         specifier: ^2.24.1
         version: 2.24.1(@vue/compiler-sfc@3.4.35)(eslint@9.8.0)(svelte@5.34.2)(typescript@5.5.4)(vitest@4.1.0-beta.6)
+      '@playwright/test':
+        specifier: ^1.58.2
+        version: 1.58.2
       '@sveltejs/vite-plugin-svelte':
         specifier: ^6.2.1
         version: 6.2.1(svelte@5.34.2)(vite@7.1.9(@types/node@24.10.1)(jiti@1.21.6)(tsx@4.17.0)(yaml@2.5.0))


### PR DESCRIPTION
I noticed that https://github.com/vitest-community/vitest-browser-svelte/pull/24 added `@playwright/test` to the dependencies, while other similar pull requests, https://github.com/vitest-community/vitest-browser-react/pull/47 and https://github.com/vitest-community/vitest-browser-vue/pull/25, only added it to devDependencies. I guess this is a mistake, as vitest browser mode doesn't have to depend on Playwright.

cc @hi-ogawa 