### PR TITLE
feat: add wrapper option

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "vitest": "^4.0.0"
   },
   "dependencies": {
-    "@testing-library/svelte-core": "^1.1.2"
+    "@testing-library/svelte-core": "^1.1.3"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^2.24.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "vitest": "^4.0.0"
   },
   "dependencies": {
-    "@testing-library/svelte-core": "^1.1.0"
+    "@testing-library/svelte-core": "^1.1.2"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^2.24.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "vitest": "^4.0.0"
   },
   "dependencies": {
-    "@testing-library/svelte-core": "^1.0.0"
+    "@testing-library/svelte-core": "^1.1.0"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^2.24.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@testing-library/svelte-core':
-        specifier: ^1.1.2
-        version: 1.1.2(svelte@5.55.9)
+        specifier: ^1.1.3
+        version: 1.1.3(svelte@5.55.9)
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^2.24.1
@@ -866,8 +866,8 @@ packages:
       svelte: ^5.46.4
       vite: ^8.0.0-beta.7 || ^8.0.0
 
-  '@testing-library/svelte-core@1.1.2':
-    resolution: {integrity: sha512-HiAsJfEiOtgqXLCAjKI5yZTbXqD0ByYBMhBxPLnw5wzMUZ050Ex3kvsxBgeXOboBUwgZWRDoRYanhp4j3z0AKQ==}
+  '@testing-library/svelte-core@1.1.3':
+    resolution: {integrity: sha512-KkMAvXeWorxN2Yn0kdC1lfoAItxpoj4uOWzxK5leDrNxonLvS5nwBFvztrroyTszQ0Wf/EU6iLT8JhY5qcn22g==}
     engines: {node: '>=16'}
     peerDependencies:
       svelte: ^3 || ^4 || ^5 || ^5.0.0-next.0
@@ -3640,7 +3640,7 @@ snapshots:
       vite: 8.0.14(@types/node@24.10.1)(esbuild@0.27.7)(jiti@1.21.6)(tsx@4.17.0)(yaml@2.5.0)
       vitefu: 1.1.3(vite@8.0.14(@types/node@24.10.1)(esbuild@0.27.7)(jiti@1.21.6)(tsx@4.17.0)(yaml@2.5.0))
 
-  '@testing-library/svelte-core@1.1.2(svelte@5.55.9)':
+  '@testing-library/svelte-core@1.1.3(svelte@5.55.9)':
     dependencies:
       svelte: 5.55.9
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@testing-library/svelte-core':
-        specifier: ^1.0.0
-        version: 1.0.0(svelte@5.55.9)
+        specifier: ^1.1.0
+        version: 1.1.0(svelte@5.55.9)
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^2.24.1
@@ -866,8 +866,8 @@ packages:
       svelte: ^5.46.4
       vite: ^8.0.0-beta.7 || ^8.0.0
 
-  '@testing-library/svelte-core@1.0.0':
-    resolution: {integrity: sha512-VkUePoLV6oOYwSUvX6ShA8KLnJqZiYMIbP2JW2t0GLWLkJxKGvuH5qrrZBV/X7cXFnLGuFQEC7RheYiZOW68KQ==}
+  '@testing-library/svelte-core@1.1.0':
+    resolution: {integrity: sha512-7ZAFtBhUI/gFoevSSg9K1zkcSETJMXxUa6qwlW1SpCOvelSbrGhr8uvjK2+REhQ5HHjXwsTUaH//FImAhT4UWg==}
     engines: {node: '>=16'}
     peerDependencies:
       svelte: ^3 || ^4 || ^5 || ^5.0.0-next.0
@@ -3640,7 +3640,7 @@ snapshots:
       vite: 8.0.14(@types/node@24.10.1)(esbuild@0.27.7)(jiti@1.21.6)(tsx@4.17.0)(yaml@2.5.0)
       vitefu: 1.1.3(vite@8.0.14(@types/node@24.10.1)(esbuild@0.27.7)(jiti@1.21.6)(tsx@4.17.0)(yaml@2.5.0))
 
-  '@testing-library/svelte-core@1.0.0(svelte@5.55.9)':
+  '@testing-library/svelte-core@1.1.0(svelte@5.55.9)':
     dependencies:
       svelte: 5.55.9
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@testing-library/svelte-core':
-        specifier: ^1.1.0
-        version: 1.1.0(svelte@5.55.9)
+        specifier: ^1.1.2
+        version: 1.1.2(svelte@5.55.9)
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^2.24.1
@@ -866,8 +866,8 @@ packages:
       svelte: ^5.46.4
       vite: ^8.0.0-beta.7 || ^8.0.0
 
-  '@testing-library/svelte-core@1.1.0':
-    resolution: {integrity: sha512-7ZAFtBhUI/gFoevSSg9K1zkcSETJMXxUa6qwlW1SpCOvelSbrGhr8uvjK2+REhQ5HHjXwsTUaH//FImAhT4UWg==}
+  '@testing-library/svelte-core@1.1.2':
+    resolution: {integrity: sha512-HiAsJfEiOtgqXLCAjKI5yZTbXqD0ByYBMhBxPLnw5wzMUZ050Ex3kvsxBgeXOboBUwgZWRDoRYanhp4j3z0AKQ==}
     engines: {node: '>=16'}
     peerDependencies:
       svelte: ^3 || ^4 || ^5 || ^5.0.0-next.0
@@ -3640,7 +3640,7 @@ snapshots:
       vite: 8.0.14(@types/node@24.10.1)(esbuild@0.27.7)(jiti@1.21.6)(tsx@4.17.0)(yaml@2.5.0)
       vitefu: 1.1.3(vite@8.0.14(@types/node@24.10.1)(esbuild@0.27.7)(jiti@1.21.6)(tsx@4.17.0)(yaml@2.5.0))
 
-  '@testing-library/svelte-core@1.1.0(svelte@5.55.9)':
+  '@testing-library/svelte-core@1.1.2(svelte@5.55.9)':
     dependencies:
       svelte: 5.55.9
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import { page } from 'vitest/browser'
 import { beforeEach } from 'vitest'
-import { cleanup, render } from './pure.js'
+import { cleanup, render, setup } from './pure.js'
 
 export { render, cleanup } from './pure.js'
 
@@ -9,6 +9,7 @@ page.extend({
   [Symbol.for('vitest:component-cleanup')]: cleanup,
 })
 
-beforeEach(() => {
+beforeEach(async () => {
   cleanup()
+  return setup()
 })

--- a/src/pure.js
+++ b/src/pure.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import { page, server, utils } from 'vitest/browser'
-import { cleanup, render as coreRender } from '@testing-library/svelte-core'
+import { cleanup, render as coreRender, wrapperSetup as setup } from '@testing-library/svelte-core'
 
 const { debug, getElementLocatorSelectors } = utils
 
@@ -69,7 +69,7 @@ function render(Component, options = {}, renderOptions = {}) {
   return { ...result, ...markThenable(locator, 'svelte.render', render, result) }
 }
 
-export { cleanup, render }
+export { cleanup, render, setup }
 
 /**
  * @template T

--- a/src/pure.js
+++ b/src/pure.js
@@ -9,11 +9,13 @@ const { debug, getElementLocatorSelectors } = utils
  * The rendered component and bound testing functions.
  *
  * @template {import('@testing-library/svelte-core/types').Component} C
+ * @template {import('@testing-library/svelte-core/types').Component} [W=never]
  *
  * @typedef {{
  *   container: HTMLElement
  *   baseElement: HTMLElement
  *   component: import('@testing-library/svelte-core/types').Exports<C>
+ *   wrapper: import('@testing-library/svelte-core/types').Exports<W>
  *   debug: (el?: HTMLElement) => void
  *   rerender: import('@testing-library/svelte-core/types').Rerender<C>
  *   unmount: () => void
@@ -29,26 +31,29 @@ const { debug, getElementLocatorSelectors } = utils
  * Please use `await render(Component)` instead of `render(Component)`.
  *
  * @template {import('@testing-library/svelte-core/types').Component} C
+ * @template {import('@testing-library/svelte-core/types').Component} [W=never]
  *
  * @param {import('@testing-library/svelte-core/types').ComponentImport<C>} Component - The component to render.
  * @param {import('@testing-library/svelte-core/types').ComponentOptions<C>} options - Customize how Svelte renders the component.
- * @param {import('@testing-library/svelte-core/types').SetupOptions} renderOptions - Customize how the document and queries are set up.
- * @returns {RenderResult<C>} The rendered component and bound testing functions.
+ * @param {import('@testing-library/svelte-core/types').SetupOptions<W>} renderOptions - Customize how the document and queries are set up.
+ * @returns {RenderResult<C, W>} The rendered component and bound testing functions.
  */
 function render(Component, options = {}, renderOptions = {}) {
-  const { baseElement, container, component, rerender, unmount } = coreRender(Component, options, renderOptions)
+  const { baseElement, container, component, wrapper, rerender, unmount } = coreRender(Component, options, renderOptions)
   ensureTestIdAttribute(baseElement)
   ensureTestIdAttribute(container)
 
   const queries = getElementLocatorSelectors(baseElement)
   const locator = page.elementLocator(container)
 
+  /** @type {RenderResult<C, W>} */
   const result = {
     baseElement,
     component,
+    wrapper,
     container,
     locator,
-    rerender: async (/** @type {any} */ props) => {
+    rerender: async (props) => {
       await rerender(props)
       await markThenable(locator, 'svelte.rerender', result.rerender, undefined)
     },

--- a/test/fixtures/Wrapper.svelte
+++ b/test/fixtures/Wrapper.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+    import type {Snippet} from 'svelte'
+    let {heading, children} = $props<{heading: string, children?: Snippet}>()
+</script>
+
+<div>
+    <h1>{heading}</h1>
+    {@render children?.()}
+</div>

--- a/test/fixtures/Wrapper.svelte
+++ b/test/fixtures/Wrapper.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {Snippet} from 'svelte'
-    let {heading, children} = $props<{heading: string, children?: Snippet}>()
+    let {heading, children} = $props<{heading: string, children: Snippet}>()
 </script>
 
 <div>

--- a/test/render.test.tsx
+++ b/test/render.test.tsx
@@ -3,6 +3,7 @@ import { page } from 'vitest/browser'
 import { render } from 'vitest-browser-svelte'
 import HelloWorld from './fixtures/HelloWorld.svelte'
 import Counter from './fixtures/Counter.svelte'
+import Wrapper from './fixtures/Wrapper.svelte'
 
 test('renders simple component', async () => {
   const screen = render(HelloWorld)
@@ -18,6 +19,18 @@ test('renders counter', async () => {
   await expect.element(screen.getByText('Count is 1')).toBeVisible()
   await screen.getByRole('button', { name: 'Increment' }).click()
   await expect.element(screen.getByText('Count is 2')).toBeVisible()
+})
+
+test('renders component in wrapper', async () => {
+  const screen = render(
+    HelloWorld,
+    {},
+    { wrapper: Wrapper, wrapperProps: { heading: 'wrapper' } },
+  )
+  await expect
+    .element(screen.getByRole('heading', { name: 'wrapper' }))
+    .toBeVisible()
+  await expect.element(screen.getByText('Hello World')).toBeVisible()
 })
 
 // test trace output by:

--- a/types/pure.d.ts
+++ b/types/pure.d.ts
@@ -6,10 +6,11 @@ export type { Component, ComponentImport, ComponentOptions, Exports, Rerender, S
 /**
  * The rendered component and bound testing functions.
  */
-export interface RenderResult<C extends Component> extends LocatorSelectors {
+export interface RenderResult<C extends Component, W extends Component = never> extends LocatorSelectors {
     container: HTMLElement;
     baseElement: HTMLElement;
     component: Exports<C>;
+    wrapper: Exports<W>;
     debug: (el?: HTMLElement) => void;
     /**
      * Update the component props. Also records a `svelte.rerender` trace mark.
@@ -38,7 +39,7 @@ export function cleanup(): void;
  * Synchronous usage is deprecated and will be removed in the next major version.
  * Please use `await render(Component)` instead of `render(Component)`.
  */
-export function render<C extends Component>(Component: ComponentImport<C>, options?: ComponentOptions<C>, renderOptions?: SetupOptions): RenderResult<C> & PromiseLike<RenderResult<C>>;
+export function render<C extends Component, W extends Component = never>(Component: ComponentImport<C>, options?: ComponentOptions<C>, renderOptions?: SetupOptions<W>): RenderResult<C, W> & PromiseLike<RenderResult<C, W>>;
 
 declare module 'vitest/browser' {
   interface BrowserPage {


### PR DESCRIPTION
Integrate the `wrapper` option from https://github.com/testing-library/svelte-testing-library/pull/492; addresses #30 

I will follow this PR up with a documentation PR over in Vitest