### PR TITLE
fix: add missing `setup` type declaration for pure entry

### DIFF
--- a/types/pure.d.ts
+++ b/types/pure.d.ts
@@ -29,6 +29,9 @@ export interface RenderResult<C extends Component, W extends Component = never> 
     locator: Locator;
 }
 
+/** Prepare the testing environment. Called automatically in `beforeEach` when using the default export. */
+export function setup(): void;
+
 /** Unmount all components and remove elements added to `<body>`. */
 export function cleanup(): void;
 

--- a/types/pure.d.ts
+++ b/types/pure.d.ts
@@ -30,7 +30,7 @@ export interface RenderResult<C extends Component, W extends Component = never> 
 }
 
 /** Prepare the testing environment. Called automatically in `beforeEach` when using the default export. */
-export function setup(): void;
+export function setup(): Promise<void>;
 
 /** Unmount all components and remove elements added to `<body>`. */
 export function cleanup(): void;


### PR DESCRIPTION
thanks for adding `wrapper` option, but `setup` type declaration is missing from `/pure` entry