### PR TITLE
fix: re-export `RenderResult` type

### DIFF
--- a/src/pure.ts
+++ b/src/pure.ts
@@ -7,7 +7,7 @@ import type { Component, ComponentImport, ComponentOptions, Exports, Rerender, S
 const { debug, getElementLocatorSelectors } = utils
 
 /** The rendered component and bound testing functions. */
-export interface RenderResult<C extends Component, W extends Component = never> extends LocatorSelectors {
+interface RenderResult<C extends Component, W extends Component = never> extends LocatorSelectors {
   container: HTMLElement
   baseElement: HTMLElement
   component: Exports<C>
@@ -69,7 +69,7 @@ function render<C extends Component, W extends Component = never>(Component: Com
   return { ...result, ...markThenable(locator, 'svelte.render', render, result) }
 }
 
-export { cleanup, render, setup }
+export { cleanup, render, setup, type RenderResult }
 export type { Component, ComponentImport, ComponentOptions, Exports, Rerender, SetupOptions } from '@testing-library/svelte-core/types'
 
 /**

--- a/src/pure.ts
+++ b/src/pure.ts
@@ -7,7 +7,7 @@ import type { Component, ComponentImport, ComponentOptions, Exports, Rerender, S
 const { debug, getElementLocatorSelectors } = utils
 
 /** The rendered component and bound testing functions. */
-interface RenderResult<C extends Component, W extends Component = never> extends LocatorSelectors {
+export interface RenderResult<C extends Component, W extends Component = never> extends LocatorSelectors {
   container: HTMLElement
   baseElement: HTMLElement
   component: Exports<C>


### PR DESCRIPTION
type `RenderResult` is not exported since v2.2.1, re-export it.